### PR TITLE
Fixing light replacer overfill error message

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -79,7 +79,7 @@
 	if(istype(W, /obj/item/stack/sheet/glass))
 		var/obj/item/stack/sheet/glass/G = W
 		if(uses >= max_uses)
-			user << "span class='warning'>[src.name] is full."
+			user << "<span class='warning'>The [src.name] is full.</span>"
 			return
 		else if(G.use(decrement))
 			AddUses(increment)

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -54,6 +54,14 @@ should be listed in the changelog upon commit tho. Thanks. -->
 <!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# --> <div class='commit sansserif'>
 
 <div class='commit sansserif'>
+	<h2 class='date'>24 February 2015</h2>
+	<h3 class='author'>Kotetsu updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='bugfix'>Fixed the light replacer's "full" message showing garbage.</li>
+	</ul>
+</div>
+
+<div class='commit sansserif'>
 	<h2 class='date'>17 February 2015</h2>
 	<h3 class='author'>Jay updated:</h3>
 	<ul class='changes bgimages16'>


### PR DESCRIPTION
The light replacer had an erroneous message when trying to fill it. Here's a fix.