### PR TITLE
20 seconds added to roundend for players to do whatever they do whenever the shuttle hits Centcomm. RCD ammo changed from normal to small, for easier and a better reason to use it

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -7,7 +7,7 @@ var/round_start_time = 0
 #define GAME_STATE_FINISHED		4
 
 /datum/controller/gameticker
-	var/const/restart_timeout = 250
+	var/const/restart_timeout = 450
 	var/current_state = GAME_STATE_PREGAME
 
 	var/hide_mode = 0

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -259,6 +259,7 @@ RCD
 	opacity = 0
 	density = 0
 	anchored = 0.0
+	w_class = 2.0
 	origin_tech = "materials=2"
 	m_amt = 16000
 	g_amt = 8000


### PR DESCRIPTION
Shouldn't cause any problems at all